### PR TITLE
Added WWW2020 GraphGen paper

### DIFF
--- a/BYVENUE.rst
+++ b/BYVENUE.rst
@@ -1921,6 +1921,14 @@ ICLR
     | :authors:`Chence, Shi, Minkai, Xu, Zhaocheng, Zhu, Weinan, Zhang, Ming, Zhang, Jian, Tang`
     | :venue:`ICLR 2020`
 
+WWW
+---
+
+`GraphGen: A Scalable Approach to Domain-agnostic Labeled Graph Generation
+<https://arxiv.org/abs/2001.08184>`_
+    | :authors:`Nikhil Goyal*, Harsh Vardhan Jain*, Sayan Ranu`
+    | :venue:`WWW 2020`
+
 Others
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -1690,6 +1690,11 @@ Graph Generation
 	| :authors:`Chence Shi, Minkai Xu, Zhaocheng Zhu, Weinan Zhang, Ming Zhang, Jian Tang`
 	| :venue:`ICLR 2020`
 
+`GraphGen: A Scalable Approach to Domain-agnostic Labeled Graph Generation
+<https://arxiv.org/abs/2001.08184>`_
+    | :authors:`Nikhil Goyal*, Harsh Vardhan Jain*, Sayan Ranu`
+    | :venue:`WWW 2020`
+
 Graph Layout and High-dimensional Data Visualization
 ====================================================
 


### PR DESCRIPTION
Adding our paper accepted in WWW2020

[Research track proceedings of our paper](https://www2020.citi.sinica.edu.tw/schedule/research_track/#Session-Social-Network-B-2)

[Arxiv paper link](https://arxiv.org/abs/2001.08184)